### PR TITLE
Quick-and-dirty Pycom LoPy (1.0) port

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -325,6 +325,11 @@ void setup()
     delay(PERIPHERAL_WARMUP_MS);
 #endif
 
+    // pycom-lora: select internal Bluetooth antenna
+    // NEEDS #define gating, constants, and a better home!
+    pinMode(16, OUTPUT);
+    digitalWrite(16, 1);
+
 #ifdef BUTTON_PIN
 #ifdef ARCH_ESP32
 
@@ -1029,7 +1034,9 @@ void setup()
     // This must be _after_ service.init because we need our preferences loaded from flash to have proper timeout values
     PowerFSM_setup(); // we will transition to ON in a couple of seconds, FIXME, only do this for cold boots, not waking from SDS
     powerFSMthread = new PowerFSMThread();
-    setCPUFast(false); // 80MHz is fine for our slow peripherals
+
+    // This was flaky for lopy
+    // setCPUFast(false); // 80MHz is fine for our slow peripherals
 }
 
 uint32_t rebootAtMsec;   // If not zero we will reboot at this time (used to reboot shortly after the update completes)

--- a/src/mesh/RadioLibRF95.cpp
+++ b/src/mesh/RadioLibRF95.cpp
@@ -4,13 +4,13 @@
 // From datasheet but radiolib doesn't know anything about this
 #define SX127X_REG_TCXO 0x4B
 
-RadioLibRF95::RadioLibRF95(Module *mod) : SX1278(mod) {}
+RadioLibRF95::RadioLibRF95(Module *mod) : SX1272(mod) {}
 
 int16_t RadioLibRF95::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t syncWord, int8_t power, uint16_t preambleLength,
                             uint8_t gain)
 {
     // execute common part
-    uint8_t rf95versions[2] = {0x12, 0x11};
+    uint8_t rf95versions[1] = {RADIOLIB_SX1272_CHIP_VERSION};
     int16_t state = SX127x::begin(rf95versions, sizeof(rf95versions), syncWord, preambleLength);
     RADIOLIB_ASSERT(state);
 

--- a/src/mesh/RadioLibRF95.h
+++ b/src/mesh/RadioLibRF95.h
@@ -6,7 +6,7 @@
 
   \brief Derived class for %RFM95 modules. Overrides some methods from SX1278 due to different parameter ranges.
 */
-class RadioLibRF95 : public SX1278
+class RadioLibRF95 : public SX1272
 {
   public:
     // constructor

--- a/variants/pycom_lopy/platformio.ini
+++ b/variants/pycom_lopy/platformio.ini
@@ -1,0 +1,10 @@
+; Meshtastic Pycom Lopy
+[env:pycom-lopy]
+board = lopy
+extends = esp32_base
+build_flags =
+  ${esp32_base.build_flags}
+  -D PRIVATE_HW
+  -D MESHTASTIC_EXCLUDE_ENVIRONMENTAL_SENSOR=1
+  -I variants/pycom_lopy
+upload_speed = 115200

--- a/variants/pycom_lopy/variant.h
+++ b/variants/pycom_lopy/variant.h
@@ -1,0 +1,33 @@
+#undef GPS_RX_PIN
+#undef GPS_TX_PIN
+
+#undef PIN_NEOPIXEL // no support
+#define LED_PIN 12
+
+#define BUTTON_NEED_PULLUP
+#define BUTTON_PIN 13 // pycom expansion board v2
+
+// Pin definition in LoPy4 Manual is incorrect. See link to errata:
+// https://forum.pycom.io/topic/3403/wiring-of-dio-pins-of-lora-sx127x-chip-to-esp32/4?_=1655162492722
+// https://forum.pycom.io/topic/3483/erratum-in-lopy4-specification-document
+// LoPy (original, not 4) pin definition:
+// https://forum.pycom.io/post/20460
+
+#define USE_RF95
+#define LORA_DIO0 23 // Note: All DIO are wired through a diode bridge to a single pin
+#define LORA_RESET 18
+#define LORA_DIO1 23 // Not really used
+#define LORA_DIO2 23 // Not really used
+
+#undef RF95_SCK
+#define RF95_SCK 5
+#undef RF95_MISO
+#define RF95_MISO 19
+#undef RF95_MOSI
+#define RF95_MOSI 27
+#undef RF95_NSS
+#define RF95_NSS 17
+
+#define HAS_SCREEN 0
+#define HAS_TELEMETRY 0
+#define HAS_SENSOR 0


### PR DESCRIPTION
Would need refactoring to make it into upstream. But hey it works!

Main changes:
* RF95 library inherits from SX1272 instead of SX1278
* Remove `setCPUFast(false)` -- was super-flaky
* Variants definition (pycom-lopy)
* Select internal bluetooth antenna in main.cpp (needs better home)

Lots of the disabled modules in variants.h were for debugging purposes but things work so leaving them as-is.

